### PR TITLE
Quip converter

### DIFF
--- a/quip_converter/README.md
+++ b/quip_converter/README.md
@@ -3,6 +3,8 @@ Convert VSI format to TIF format. It can run a single image or multiple images.
 * Run single image, see sample input file: ```input_one.json```
 * Run multiple images, see sample input file: ```inputs_list.json```
 
+Replace the url in field ```wf_quip_converter_vsi_to_tiff.convert.vsiInput``` with your vsi image url on Google bucket.
+
 ## v1
-Support the input vsi image in zip or tar.gz format, and located in google bucket.
+Support the input vsi image in zip or tar.gz format, and located in Google bucket.
 

--- a/quip_converter/README.md
+++ b/quip_converter/README.md
@@ -1,0 +1,8 @@
+# Quip Converter
+Convert VSI format to TIF format. It can run a single image or multiple images.
+* Run single image, see sample input file: ```input_one.json```
+* Run multiple images, see sample input file: ```inputs_list.json```
+
+## v1
+Support the input vsi image in zip or tar.gz format, and located in google bucket.
+

--- a/quip_converter/v1/input_one.json
+++ b/quip_converter/v1/input_one.json
@@ -1,0 +1,6 @@
+[
+    {
+       "wf_quip_converter_vsi_to_tiff.convert.vsiInput": "gs://cloudypipelines-test_cromwell_outputs/input_images/vsi/OS-1.zip",
+       "wf_quip_converter_vsi_to_tiff.convert.tifOutput": "multires.tif"
+    }
+]

--- a/quip_converter/v1/inputs_list.json
+++ b/quip_converter/v1/inputs_list.json
@@ -1,0 +1,10 @@
+[
+    {
+       "wf_quip_converter_vsi_to_tiff.convert.vsiInput": "gs://cloudypipelines-test_cromwell_outputs/input_images/vsi/OS-1.zip",
+       "wf_quip_converter_vsi_to_tiff.convert.tifOutput": "multires.tif"
+    },
+    {
+        "wf_quip_converter_vsi_to_tiff.convert.vsiInput": "gs://cloudypipelines-test_cromwell_outputs/input_images/vsi/OS-2.zip",
+        "wf_quip_converter_vsi_to_tiff.convert.tifOutput": "multires.tif"
+     }
+]

--- a/quip_converter/v1/quip_converter.wdl
+++ b/quip_converter/v1/quip_converter.wdl
@@ -1,0 +1,37 @@
+task convert {
+  File vsiInput
+  String tifOutput
+  command {
+    echo "$(date): Task: convert started"
+    set -x
+    mkdir -p /quip_convert/vsi
+    mkdir -p /quip_convert/tif
+    mv ${vsiInput} /quip_convert/vsi/$(basename ${vsiInput})
+    cd /quip_convert/vsi
+    [[ /quip_convert/vsi/$(basename ${vsiInput}) =~ \.tar\.gz$ ]] && ( echo "input is tar.gz file"; tar xzvf ./*.tar.gz )
+    [[ /quip_convert/vsi/$(basename ${vsiInput}) =~ \.zip$ ]] && ( echo "input is zip file"; unzip ./*.zip )
+    cd /root
+    time run_convert_wsi.sh $( ls /quip_convert/vsi/*.vsi ) /quip_convert/tif/big.tif /quip_convert/tif/multi.tif
+    mv /quip_convert/tif/multi.tif /cromwell_root/${tifOutput}
+    echo "$(date): Task: convert finished"
+  }
+  output {
+    File out="${tifOutput}"
+  }
+  runtime {
+    docker: "us.gcr.io/cloudypipelines/quip_converter_to_tiff:1.1"
+    bootDiskSizeGb: 50
+    disks: "local-disk 50 SSD"
+    memory:  "12 GB"
+    cpu: "2"
+    maxRetries: 1
+    zones: "us-east1-b us-east1-c us-east1-d us-central1-a us-central1-b us-central1-c us-central1-f us-east4-a us-east4-b us-east4-c us-west1-a us-west1-b us-west1-c us-west2-a us-west2-b us-west2-c"
+  }
+}
+
+workflow wf_quip_converter_vsi_to_tiff {
+  call convert
+  output {
+     convert.out
+  }
+}


### PR DESCRIPTION
- Convert vsi to tif
- The input vsi image files are compressed in zip or tar.gz format
- The input vsi image compressed files are located on Google buckets